### PR TITLE
Manuals aren't linking to correct page.

### DIFF
--- a/blocks/resources/resources.js
+++ b/blocks/resources/resources.js
@@ -9,6 +9,7 @@ async function lookupFiles(fileSource, category) {
 
 export default async function decorate(block) {
   const locale = getMetadata('locale');
+  const lang = locale.replace(/\w+\/(\w+)/, '$1');
   const placeholders = await fetchPlaceholders(locale);
 
   const fileSource = new URL(block.querySelector('a').href);
@@ -43,6 +44,7 @@ export default async function decorate(block) {
     titles.push('titleLabel', 'manualNumberLabel', 'sizeLabel');
 
     const downloadURL = 'https://www.graco.com/bin.findManual?source=airlessco&manual=';
+    const langParam = '&lang=';
     resources.forEach((obj) => {
       const resource = createTag('tr', { class: 'resource' });
       const manualNumber = obj.Manual_Number;
@@ -50,7 +52,7 @@ export default async function decorate(block) {
         if (key === ('Title') || key === ('Manual_Number')) {
           const resourceData = createTag('td', { class: 'resource-data' });
           const resourceLink = createTag('a', { class: 'resource-link' });
-          resourceLink.setAttribute('href', `${downloadURL}${manualNumber}`);
+          resourceLink.setAttribute('href', `${downloadURL}${manualNumber}${langParam}${lang}`);
           resourceLink.setAttribute('target', 'new');
           resourceLink.innerText = `${value}`;
           resourceData.append(resourceLink);

--- a/blocks/resources/resources.js
+++ b/blocks/resources/resources.js
@@ -9,7 +9,7 @@ async function lookupFiles(fileSource, category) {
 
 export default async function decorate(block) {
   const locale = getMetadata('locale');
-  const lang = locale.replace(/\w+\/(\w+)/, '$1');
+  const lang = locale.replace(/^\/\w+\/(\w+)$/, '$1');
   const placeholders = await fetchPlaceholders(locale);
 
   const fileSource = new URL(block.querySelector('a').href);

--- a/blocks/resources/resources.js
+++ b/blocks/resources/resources.js
@@ -43,7 +43,7 @@ export default async function decorate(block) {
     const resources = await lookupFiles(fileSource, category);
     titles.push('titleLabel', 'manualNumberLabel', 'sizeLabel');
 
-    const downloadURL = 'https://www.graco.com/bin.findManual?source=airlessco&manual=';
+    const downloadURL = 'https://www.graco.com/bin/findManual?source=airlessco&manual=';
     const langParam = '&lang=';
     resources.forEach((obj) => {
       const resource = createTag('tr', { class: 'resource' });


### PR DESCRIPTION

Fix #176 

Test URLs:
- Before: https://main--airlessco--hlxsites.hlx.page/emea/de/support/manuals/
- After: https://bug-resources-language-links--airlessco--hlxsites.hlx.page/emea/de/support/manuals/
